### PR TITLE
Add support for out-of-order validation of a message hash chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+notes
 /target
 **/*.rs.bk
 Cargo.lock

--- a/README.md
+++ b/README.md
@@ -10,14 +10,20 @@
 ## About
 
 Secure Scuttlebutt "feeds" are a sequence of messages published by one author.
-To be a valid message,
-- each message must include the hash of the preceding message
-- the sequence number must be one larger than sequence of the preceding message
-- the author must not change compared to the preceding message
-- If it's the first message in a feed, the sequence must be 1 and the previous must be null.
-- If the message includes the key, it must be that hash of the value of the message..
+To be valid, a message should satisfy the following criteria:
+
+ - include the hash of the previous message
+   - unless it is the first message in feed, in which case previous must be null
+ - include a sequence number which is 1 larger than the sequence number of the previous message
+   - unless it is the first message in a feed, in which case the sequence number must be 1 and the sequence number of the previous message must be null
+ - the author must not change compared to the previous message
+ - if the message includes a key, it must be the hash of the value of the message
 
 You can check messages one by one or batch process a collection of them (uses [rayon](https://docs.rs/rayon/1.2.0/rayon/index.html) internally)
+
+In addition to validating messages using all of the above criteria, it is also possible to validate out-of-order messages by satifying a subset of those criteria. This crate provides functions to perform batch validation of such out-of-order messages.
+
+Out-of-order messages must be authored by a single keypair. However, it is not required that the sequence number of a message be 1 larger than the sequence number of the previous message, nor is it required that the hash of the previous message match the hash given for the previous message in a message.
 
 ## Benchmarks
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,14 +177,10 @@ pub fn validate_ooo_message_hash_chain<T: AsRef<[u8]>, U: AsRef<[u8]>>(
 ///
 /// It expects the messages to be the JSON encoded message of shape: `{key: "", value: {...}}`
 
-pub fn par_validate_ooo_message_hash_chain_of_feed<T: AsRef<[u8]>, U: AsRef<[u8]>>(
-    messages: &[T],
-    previous: Option<U>,
-) -> Result<()>
+pub fn par_validate_ooo_message_hash_chain_of_feed<T: AsRef<[u8]>>(messages: &[T]) -> Result<()>
 where
     [T]: ParallelSlice<T>,
     T: Sync,
-    U: Sync + Send + Copy,
 {
     messages
         .par_iter()
@@ -193,11 +189,7 @@ where
             || (),
             |_, (idx, msg)| {
                 if idx == 0 {
-                    let prev = match previous {
-                        Some(prev) => Some(prev.as_ref().to_owned()),
-                        _ => None,
-                    };
-                    validate_ooo_message_hash_chain(msg.as_ref(), prev)
+                    validate_ooo_message_hash_chain::<_, &[u8]>(msg.as_ref(), None)
                 } else {
                     validate_ooo_message_hash_chain(msg.as_ref(), Some(messages[idx - 1].as_ref()))
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -683,7 +683,11 @@ mod tests {
     }
     #[test]
     fn par_validate_ooo_message_hash_chain_of_feed_with_first_message_works() {
-        let messages = [MESSAGE_1.as_bytes(), MESSAGE_3.as_bytes()];
+        let messages = [
+            MESSAGE_1.as_bytes(),
+            MESSAGE_3.as_bytes(),
+            MESSAGE_2.as_bytes(),
+        ];
 
         let result = par_validate_ooo_message_hash_chain_of_feed::<_, &[u8]>(&messages[..], None);
         assert!(result.is_ok());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -697,23 +697,14 @@ mod tests {
             MESSAGE_2.as_bytes(),
         ];
 
-        let result = par_validate_ooo_message_hash_chain_of_feed::<_, &[u8]>(&messages[..], None);
-        assert!(result.is_ok());
-    }
-    #[test]
-    fn par_validate_ooo_message_hash_chain_of_feed_with_prev_works() {
-        let messages = [MESSAGE_3.as_bytes()];
-
-        let result =
-            par_validate_ooo_message_hash_chain_of_feed(&messages[..], Some(MESSAGE_1.as_bytes()));
+        let result = par_validate_ooo_message_hash_chain_of_feed(&messages[..]);
         assert!(result.is_ok());
     }
     #[test]
     fn par_validate_ooo_message_hash_chain_of_feed_without_first_message_works() {
-        let messages = [MESSAGE_3.as_bytes()];
+        let messages = [MESSAGE_3.as_bytes(), MESSAGE_2.as_bytes()];
 
-        let result =
-            par_validate_ooo_message_hash_chain_of_feed(&messages[..], Some(MESSAGE_2.as_bytes()));
+        let result = par_validate_ooo_message_hash_chain_of_feed(&messages[..]);
         assert!(result.is_ok());
     }
     // NEW TESTS END

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,22 @@ struct SsbMessage {
     value: SsbMessageValue,
 }
 
-// only check a single message (no previous)
+/// Check that an out-of-order message is valid.
+///
+/// It expects the messages to be the JSON encoded message of shape: `{key: "", value: {...}}`
+///
+/// This checks that:
+/// - the author has not changed
+/// - the _actual_ hash matches the hash claimed in `key`
+/// - the message contains the correct fields
+///
+/// This does not check:
+/// - the signature. See ssb-verify-signatures which lets you to batch verification of signatures.
+/// - the sequence increments by 1 compared to previous
+/// - the _actual_ hash of the previous message matches the hash claimed in `previous`
+///
+/// `previous_msg_bytes` will be `None` only when `message_bytes` is the first message by that author.
+
 pub fn validate_ooo_message_hash_chain<T: AsRef<[u8]>, U: AsRef<[u8]>>(
     message_bytes: T,
     previous_msg_bytes: Option<U>,
@@ -155,7 +170,8 @@ pub fn validate_ooo_message_hash_chain<T: AsRef<[u8]>, U: AsRef<[u8]>>(
     Ok(())
 }
 
-/// Batch validates a collection of out-of-order messages by a single author. Missing
+/// Batch validates a collection of out-of-order messages by a single author. Checks of previous
+/// message hash and ascending sequence number are not performed, meaning that missing
 /// messages are allowed and the collection is not expected to be ordered by ascending sequence
 /// number.
 ///


### PR DESCRIPTION
# Introduce out-of-order validation

This PR introduces the code additions proposed in https://github.com/sunrise-choir/ssb-validate/issues/2 .

Two functions are added, along with doc comments and unit tests:

```rust
validate_ooo_message_hash_chain()
par_validate_ooo_message_hash_chain_of_feed()
```

I have done my best to conform to the existing style and structure of the crate. I also altered the wording of the message validity criteria in the README (this is more of a personal preference...doesn't need to be included if it doesn't appeal to the crate authors).