### PR TITLE
Add checks and unit tests for hash signature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ license = "AGPL-3.0"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.8.0"
 snafu = "0.6.0"
-ssb-legacy-msg-data = "0.1.2"
+#ssb-legacy-msg-data = "0.1.2"
+ssb-legacy-msg-data = { path = "../ssb-legacy-msg-data" }
 ssb-multiformats = "0.4.0" 
 rayon = "1.2.0"
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ To be valid, a message should satisfy the following criteria:
    - unless it is the first message in feed, in which case previous must be null
  - include a sequence number which is 1 larger than the sequence number of the previous message
    - unless it is the first message in a feed, in which case the sequence number must be 1 and the sequence number of the previous message must be null
+ - include a hash function field with value `sha256`
  - the author must not change compared to the previous message
  - if the message includes a key, it must be the hash of the value of the message
 


### PR DESCRIPTION
Adds a `hash` field to the `SsbMessageValue` `struct` and performs a check of `message_value.hash == "sha256"` to the common checks. This criterion for validity has been added to the checklist in the README.

Unit tests and example messages have been included to ensure that messages without a `hash` field are rendered invalid, as are messages for which the hash function is not `sha256`.