### PR TITLE
Deny unknown fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,6 @@ struct SsbMessageValue {
     sequence: u64,
     timestamp: LegacyF64,
     hash: String,
-    content: Value,
     signature: String,
 }
 


### PR DESCRIPTION
Further experimentation in closing the gap between validation in the JavaScript and Rust SSB implementations of ssb-validate. Testing with [ssb-validation-dataset](https://github.com/fraction/ssb-validation-dataset).

This PR adds a `signature` field to the `SsbMessageValue` `struct`. The [serde `deny_unknown_fields` container attribute](https://serde.rs/container-attrs.html#deny_unknown_fields) is also added. This ensures strict deserialization of message values and results in failed validation if a message value include extraneous fields. An example message and unit test have been included.