### PR TITLE
Update dependencies to use fork of legacy-msg-data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.8.0"
 snafu = "0.6.0"
 #ssb-legacy-msg-data = "0.1.2"
-ssb-legacy-msg-data = { path = "../ssb-legacy-msg-data" }
+ssb-legacy-msg-data = { git = "https://github.com/mycognosist/legacy-msg-data" }
 ssb-multiformats = "0.4.0" 
 rayon = "1.2.0"
 


### PR DESCRIPTION
Use @mycognosist fork of [legacy-msg-data](https://github.com/mycognosist/legacy-msg-data) as dependency (more up-to-date).