### PR TITLE
Introduce stricter deserialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
 use ssb_legacy_msg_data::json::{from_slice, to_vec, DecodeJsonError, EncodeJsonError};
-use ssb_legacy_msg_data::value::Value;
+use ssb_legacy_msg_data::value::{ContentValue, Value};
 use ssb_legacy_msg_data::LegacyF64;
 use ssb_multiformats::multihash::Multihash;
 
@@ -87,7 +87,7 @@ struct SsbMessageValue {
     sequence: u64,
     timestamp: LegacyF64,
     hash: String,
-    content: Value,
+    content: ContentValue,
     signature: String,
 }
 


### PR DESCRIPTION
This PR changes the value of the message `content` field from `Value` to `ContentValue`. `ContentValue` implements stricter deserialization rules.

Previously, any valid JSON type was allowable as the `content` field type - resulting in validation leniency which did not meet the full validation requirements of the Scuttlebutt protocol. As an example, a message with `"content": true` would previously have passed validation. With this PR, `content` must be a `str` or `String` containing `.box` (encrypted private message) or a `Map` of `String`: `Value` - where `Value` represents any valid JSON type (as defined in [ssb-legacy-msg-data](https://docs.rs/ssb-legacy-msg-data/0.1.2/ssb_legacy_msg_data/value/enum.Value.html)).