### PR TITLE
Introduce canonical base64 check for private messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "ssb-validate"
-version = "1.0.1"
-authors = ["Piet Geursen <pietgeursen@gmail.com>"]
+version = "1.1.0"
+authors = ["Piet Geursen <pietgeursen@gmail.com>", "Andrew Reid <glyph@mycelial.technology>"]
 edition = "2018"
 description = "Verify Secure Scuttlebutt (SSB) hash chains (in parallel)"
-repository = "https://github.com/sunrise-choir/ssb-validate"
+repository = "https://github.com/mycognosist/ssb-validate"
 documentation = "https://docs.rs/ssb-validate/"
 license = "AGPL-3.0"
 
@@ -13,7 +13,6 @@ regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.8.0"
 snafu = "0.6.0"
-#ssb-legacy-msg-data = "0.1.2"
 ssb-legacy-msg-data = { git = "https://github.com/mycognosist/legacy-msg-data" }
 ssb-multiformats = "0.4.0" 
 rayon = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/ssb-validate/"
 license = "AGPL-3.0"
 
 [dependencies]
+regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.8.0"
 snafu = "0.6.0"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ To be valid, a message should satisfy the following criteria:
  - include a hash function field with value `sha256`
  - the author must not change compared to the previous message
  - if the message includes a key, it must be the hash of the value of the message
+ - the message value must not include extra fields
+ - if the message content is a string (encrypted private message) it must be encoded in canonical base64 and end with `.box`
+
+All of the above criteria are validated by this library (either directly or via dependencies).
 
 You can check messages one by one or batch process a collection of them (uses [rayon](https://docs.rs/rayon/1.2.0/rayon/index.html) internally)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 //! Benchmarking on Android on a [One Plus 5T](https://en.wikipedia.org/wiki/OnePlus_5T) (8 core arm64) shows that batch processing is ~3.3 times faster.
 //!
 use rayon::prelude::*;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
@@ -52,6 +53,8 @@ pub enum Error {
     FirstMessageDidNotHavePreviousOfNull { message: Vec<u8> },
     #[snafu(display("The message hash must be 'sha256'",))]
     InvalidHashFunction { message: Vec<u8> },
+    #[snafu(display("The message content string must be canonical base64",))]
+    InvalidBase64 { message: Vec<u8> },
     #[snafu(display("The sequence must increase by one",))]
     InvalidSequenceNumber {
         message: Vec<u8>,
@@ -619,6 +622,19 @@ fn message_value_common_checks(
         }
     );
 
+    // The message `content` string must be canonical base64.
+    if let Value::String(private_msg) = &message_value.content.0 {
+        // Regex pattern to match on canonical base64 for private messages.
+        // Implemented according to the `is-canonical-base64` JS module by dominictarr.
+        let re = Regex::new(r"^(?:[a-zA-Z0-9/+]{4})*(?:[a-zA-Z0-9/+](?:(?:[AQgw]==)|(?:[a-zA-Z0-9/+][AEIMQUYcgkosw048]=)))?.box.*$").unwrap();
+        ensure!(
+            re.is_match(private_msg),
+            InvalidBase64 {
+                message: message_bytes,
+            }
+        );
+    }
+
     if let Some(previous_value) = previous_value {
         // The authors are not allowed to change in a feed.
         ensure!(
@@ -889,6 +905,27 @@ mod tests {
         );
 
         assert!(result.is_ok());
+    }
+    #[test]
+    fn it_validates_a_private_message() {
+        let result = validate_message_hash_chain(
+            MESSAGE_PRIVATE.as_bytes(),
+            Some(MESSAGE_PRIVATE_PREV.as_bytes()),
+        );
+
+        assert!(result.is_ok());
+    }
+    #[test]
+    fn it_detects_invalid_base64_for_private_message() {
+        let result = validate_message_hash_chain(
+            MESSAGE_PRIVATE_INVALID.as_bytes(),
+            Some(MESSAGE_PRIVATE_PREV.as_bytes()),
+        );
+
+        match result {
+            Err(Error::InvalidBase64 { message: _ }) => {}
+            _ => panic!(),
+        }
     }
 
     const MESSAGE_1: &str = r##"{
@@ -1222,5 +1259,54 @@ mod tests {
     "extra": "INVALID"
     },
   "timestamp": 1571140555382.002
+}"##;
+
+    const MESSAGE_PRIVATE: &str = r##"{
+  "key": "%uN9G3nZ+IYrCiC8Qmqb8J8hnefc486pZGeWyqBomAi8=.sha256",
+  "value": {
+    "previous": "%Z694dkKDUmNtoSwwjLG9cl7j0Dd26EDp0DRDmyPl1Lc=.sha256",
+    "sequence": 24148,
+    "author": "@iL6NzQoOLFP18pCpprkbY80DMtiG4JFFtVSVUaoGsOQ=.ed25519",
+    "timestamp": 1620171292121,
+    "hash": "sha256",
+    "content": "siZEm1zFx1icq0SrEynGDpNRmJCXMxTB3iEteXFn+IhJH8WhMbT8tp9qOIaFkIYcdOyerSon6RK0l4RE1ZdDh/3lcGZSdP0Ljq59qsdqlf2ngwbIbV9AWdPRrPsoVZBV6RhI+YcVTloWWP5aauu1hZKjcm62ezLBTQ3EmFPYtDuwsOFkx9/7FP97ljhj67CwvlGzuiWp6FNICHbt5kOCxs9H0k6Tr8JJVdaJtJ2pqkX4p0ECMuEuYxCYbh3FpncCqlNZJXb0dj3iSsfsMNWTJLDqfkqJKH1jBVfxDL6+xAXBDS+E4F2hD4y9gRDZEej99uVBQWlbxr5eCRV+VbfBGYxwoAYtqux6rg3jBabImKKinBwHShEP5F/+wlb9IxQn4swyOgyv+UKx/jbx+91Ayso5bnNPZMpwRRX5p5DbpK1BnryeVJhktMgFqgni1g0lHyU8sQ2QzwZgXGw7dfYoamkqK4D24NOLnUoHuVuhd7Q5SxZWSAO6wpDa4nrODePoJdl328pbMwCoQlUNeHINmKxh/o/oCNbgXitn4oN3kSVEg/umdgwwI94gmZUjiYwP1v7HA7dI.box",
+    "signature": "n4Wepa4fxq+xLlmfCxwiC489rMZlnnrBFOkWMuGAv80O7GK0XZUn1zfuCP9fQBab1+P0m1g+OLiyWwqHnwdTBw==.sig.ed25519"
+    },
+  "timestamp": 1620198134771
+}"##;
+
+    const MESSAGE_PRIVATE_PREV: &str = r##"{
+  "key": "%Z694dkKDUmNtoSwwjLG9cl7j0Dd26EDp0DRDmyPl1Lc=.sha256",
+  "value": {
+    "previous": "%cN1F3DkKC3bfxZlwWY98xqzsoQGEC9sRNe9HYm6khhk=.sha256",
+    "sequence": 24147,
+    "author": "@iL6NzQoOLFP18pCpprkbY80DMtiG4JFFtVSVUaoGsOQ=.ed25519",
+    "timestamp": 1620136240655,
+    "hash": "sha256",
+    "content": {
+      "type": "vote",
+      "vote": {
+        "link": "%SXw+GJZZBvS7neNDfuyu2UXmGD3Gl8jMxX2PPc7sjCs=.sha256",
+        "value": 1,
+        "expression": "Like"
+      }
+    },
+    "signature": "iA958Ct3+9Z3tZZcbXvF4BAFVPJZ8MhfqnWOgzwhLdviL1KE3xTKn4joJl1a+mnqSLHbH/QT3NHQu378GdsHBg==.sig.ed25519"
+    },
+  "timestamp": 1620137278131.001
+}"##;
+
+    const MESSAGE_PRIVATE_INVALID: &str = r##"{
+  "key": "%uN9G3nZ+IYrCiC8Qmqb8J8hnefc486pZGeWyqBomAi8=.sha256",
+  "value": {
+    "previous": "%Z694dkKDUmNtoSwwjLG9cl7j0Dd26EDp0DRDmyPl1Lc=.sha256",
+    "sequence": 24148,
+    "author": "@iL6NzQoOLFP18pCpprkbY80DMtiG4JFFtVSVUaoGsOQ=.ed25519",
+    "timestamp": 1620171292121,
+    "hash": "sha256",
+    "content": "==siZEm1zFx1icq0SrEynGDpNRmJCXMxTB3iEteXFn+IhJH8WhMbT8tp9qOIaFkIYcdOyerSon6RK0l4RE1ZdDh/3lcGZSdP0Ljq59qsdqlf2ngwbIbV9AWdPRrPsoVZBV6RhI+YcVTloWWP5aauu1hZKjcm62ezLBTQ3EmFPYtDuwsOFkx9/7FP97ljhj67CwvlGzuiWp6FNICHbt5kOCxs9H0k6Tr8JJVdaJtJ2pqkX4p0ECMuEuYxCYbh3FpncCqlNZJXb0dj3iSsfsMNWTJLDqfkqJKH1jBVfxDL6+xAXBDS+E4F2hD4y9gRDZEej99uVBQWlbxr5eCRV+VbfBGYxwoAYtqux6rg3jBabImKKinBwHShEP5F/+wlb9IxQn4swyOgyv+UKx/jbx+91Ayso5bnNPZMpwRRX5p5DbpK1BnryeVJhktMgFqgni1g0lHyU8sQ2QzwZgXGw7dfYoamkqK4D24NOLnUoHuVuhd7Q5SxZWSAO6wpDa4nrODePoJdl328pbMwCoQlUNeHINmKxh/o/oCNbgXitn4oN3kSVEg/umdgwwI94gmZUjiYwP1v7HA7dI.box",
+    "signature": "n4Wepa4fxq+xLlmfCxwiC489rMZlnnrBFOkWMuGAv80O7GK0XZUn1zfuCP9fQBab1+P0m1g+OLiyWwqHnwdTBw==.sig.ed25519"
+    },
+  "timestamp": 1620198134771
 }"##;
 }


### PR DESCRIPTION
This PR introduces Regex to ensure that private messages conform to the canonical base64 encoding, as defined in the [is-canonical-base64](https://github.com/dominictarr/is-canonical-base64) library by Dominic Tarr. The corresponding check in the JavaScript implementation can be found on [L59 of `index.js`](https://github.com/ssb-js/ssb-validate/blob/main/index.js#L59) in ssb-validate. Passing and failing tests are included here.

The README has been updated to reflect this validation check (as well as a previously-implemented 'no extra fields' check).

The manifest has been updated to bump the crate version, reflect my co-authorship (I think this is fair?) and include the Regex dependency.

-----

_Note to self:_ I must now remove the `.box` check from `ssb-legacy-msg-data` deserialization since this PR renders it redundant.