### PR TITLE
Implement message key ordering check with Regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ documentation = "https://docs.rs/ssb-validate/"
 license = "AGPL-3.0"
 
 [dependencies]
+lazy_static = "1.4.0"
+regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.8.0"
 snafu = "0.6.0"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To be valid, a message should satisfy the following criteria:
  - include a hash function field with value `sha256`
  - the author must not change compared to the previous message
  - if the message includes a key, it must be the hash of the value of the message
+ - message value keys must be in the order: "previous", "author"|"sequence", "author"|"sequence", "timestamp", "hash", "content", "signature"
 
 You can check messages one by one or batch process a collection of them (uses [rayon](https://docs.rs/rayon/1.2.0/rayon/index.html) internally)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,22 @@ pub fn validate_ooo_message_hash_chain<T: AsRef<[u8]>, U: AsRef<[u8]>>(
 
     let message_value = message.value;
 
+    // The message value fields are in the correct order.
+    ensure!(
+        is_correct_order(message_bytes),
+        InvalidMessageValueOrder {
+            message: message_bytes.to_owned()
+        }
+    );
+
+    // The hash signature must be `sha256`.
+    ensure!(
+        message_value.hash == "sha256",
+        InvalidHashFunction {
+            message: message_bytes.to_owned()
+        }
+    );
+
     if let Some(previous_value) = previous_value.as_ref() {
         // The authors are not allowed to change in a feed.
         ensure!(


### PR DESCRIPTION
This PR offers an answer to the question: **how do we ensure strict ordering of the keys (fields) of an SSB message value?** Since we are unable to enforce this during deserialization, an alternative approach is to match on the message bytes using a regular expression:

`"previous"[\s\S]*("author"|"sequence")[\s\S]*("author"|"sequence")[\s\S]*"timestamp"[\s\S]*"hash"[\s\S]*"content"[\s\S]*"signature"`

This only matches if each field appears in the given order. The second and third fields may be swapped, as is defined on [L19 of `index.js`](https://github.com/ssb-js/ssb-validate/blob/main/index.js#L19) in the JavaScript implementation of `ssb-validate`.

The `lazy_static` crate is used to ensure the regular expression is compiled exactly once ([compiling the same regular expression in a loop is an anti-pattern](https://docs.rs/regex/1.5.3/regex/#example-avoid-compiling-the-same-regex-in-a-loop), and an expensive one at that).

A test has been added and fails correctly. All other tests for this crate are passing. Tests for `ssb-validate2-rsjs` using this code are passing.