### PR TITLE
Add multi-author out-of-order validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-validate"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Piet Geursen <pietgeursen@gmail.com>", "Andrew Reid <glyph@mycelial.technology>"]
 edition = "2018"
 description = "Verify Secure Scuttlebutt (SSB) hash chains (in parallel)"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 > Verify Secure Scuttlebutt (SSB) hash chains (in parallel)
 
+**THIS FORK DEVIATES SIGNIFICANTLY FROM THE ORIGINAL VERSION!** Support for out-of-order validation (regular and parallel) and multi-author out-of-order validation (regular and parallel) has been added.
+
 ## Docs
 
 [Rustdocs](https://sunrise-choir.github.io/ssb-validate/ssb_validate/index.html)
@@ -29,7 +31,11 @@ You can check messages one by one or batch process a collection of them (uses [r
 
 In addition to validating messages using all of the above criteria, it is also possible to validate out-of-order messages by satifying a subset of those criteria. This crate provides functions to perform batch validation of such out-of-order messages.
 
-Out-of-order messages must be authored by a single keypair. However, it is not required that the sequence number of a message be 1 larger than the sequence number of the previous message, nor is it required that the hash of the previous message match the hash given for the previous message in a message.
+Out-of-order message validation may be performed for single-author or multi-author use-cases (separate functions exist for each case).
+
+When performing validation for out-of-order messages from a single author, the messages must be authored by a single keypair. However, it is not required that the sequence number of a message be 1 larger than the sequence number of the previous message, nor is it required that the hash of the previous message match the hash given for the previous message in a message.
+
+Multi-author out-of-order validation, by contrast to the above, does not perform any checks of the `previous` message. Indeed, it may be said that this method of validation has no concept of a previous message (except that the `previous` field must be present in the message in the correct order).
 
 ## Benchmarks
 


### PR DESCRIPTION
This PR adds two new functions: one which allows validation of a single out-of-order message and one which allows parallel bulk validation of a collection of out-of-order message by multiple authors. Unit tests have been added to ensure correct validation of a single message and a collection of messages by multiple authors.

From the README:

```rust
/// Check that an out-of-order message is valid without checking the author.
///
/// It expects the messages to be the JSON encoded message of shape: `{key: "", value: {...}}`
///
/// This checks that:
/// - the _actual_ hash matches the hash claimed in `key`
/// - the message contains the correct fields
/// - the message value fields are in the correct order
/// - there are no unexpected top-level fields in the message
/// - the hash signature is defined as `sha256`
/// - the message `content` string is canonical base64
///
/// This does not check:
/// - the signature (see ssb-verify-signatures which lets you to batch verification of signatures)
/// - the previous message
///   - no check of the sequence to ensure it increments by 1 compared to previous
///   - no check that the _actual_ hash of the previous message matches the hash claimed in `previous`
///   - no check that the author has not changed
```